### PR TITLE
Use nested multiparts + use attachment list

### DIFF
--- a/data/keycloak/themes/base/email/html/email-test.ftl
+++ b/data/keycloak/themes/base/email/html/email-test.ftl
@@ -1,6 +1,5 @@
 <html>
 <body>
 ${kcSanitize(msg("emailTestBodyHtml",realmName))?no_esc}
-<div src="cid:testfile"></div>
 </body>
 </html>

--- a/data/keycloak/themes/base/email/html/email-test.ftl
+++ b/data/keycloak/themes/base/email/html/email-test.ftl
@@ -1,5 +1,6 @@
 <html>
 <body>
 ${kcSanitize(msg("emailTestBodyHtml",realmName))?no_esc}
+<!-- !attach:files/test.pdf -->
 </body>
 </html>

--- a/data/keycloak/themes/base/email/html/email-verification.ftl
+++ b/data/keycloak/themes/base/email/html/email-verification.ftl
@@ -1,5 +1,6 @@
 <html>
 <body>
 ${kcSanitize(msg("emailVerificationBodyHtml",link, linkExpiration, realmName, linkExpirationFormatter(linkExpiration)))?no_esc}
+<!-- !attach:files/test.pdf -->
 </body>
 </html>

--- a/data/keycloak/themes/base/email/html/email-verification.ftl
+++ b/data/keycloak/themes/base/email/html/email-verification.ftl
@@ -1,6 +1,5 @@
 <html>
 <body>
 ${kcSanitize(msg("emailVerificationBodyHtml",link, linkExpiration, realmName, linkExpirationFormatter(linkExpiration)))?no_esc}
-<div src="cid:testfile"></div>
 </body>
 </html>

--- a/data/keycloak/themes/base/email/theme.properties
+++ b/data/keycloak/themes/base/email/theme.properties
@@ -1,2 +1,1 @@
 locales=ca,cs,da,de,en,es,fr,hu,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh
-attachments=files/test.pdf

--- a/data/keycloak/themes/base/email/theme.properties
+++ b/data/keycloak/themes/base/email/theme.properties
@@ -1,2 +1,2 @@
 locales=ca,cs,da,de,en,es,fr,hu,it,ja,lt,nl,no,pl,pt-BR,ru,sk,sv,tr,zh
-attach_testfile=files/test.pdf
+attachments=files/test.pdf

--- a/src/main/java/org/keycloak/email/EmailWithAttachmentSenderProvider.java
+++ b/src/main/java/org/keycloak/email/EmailWithAttachmentSenderProvider.java
@@ -84,7 +84,7 @@ public class EmailWithAttachmentSenderProvider implements EmailSenderProvider {
 
             Session session = Session.getInstance(props);
 
-            Multipart multipart = new MimeMultipart("alternative");
+            Multipart multipart = new MimeMultipart("mixed");
 
             if (textBody != null) {
                 MimeBodyPart textPart = new MimeBodyPart();

--- a/src/main/java/org/keycloak/email/EmailWithAttachmentSenderProvider.java
+++ b/src/main/java/org/keycloak/email/EmailWithAttachmentSenderProvider.java
@@ -82,7 +82,7 @@ public class EmailWithAttachmentSenderProvider implements EmailSenderProvider {
 
             Session session = Session.getInstance(props);
 
-            Multipart multipart = new MimeMultipart("mixed");
+            Multipart outerMultipart = new MimeMultipart("mixed");
             Multipart innerMultipart = new MimeMultipart("alternative");
 
             if (textBody != null) {
@@ -99,10 +99,10 @@ public class EmailWithAttachmentSenderProvider implements EmailSenderProvider {
 
             MimeBodyPart innerMultiPartBody = new MimeBodyPart();
             innerMultiPartBody.setContent(innerMultipart);
-            multipart.addBodyPart(innerMultiPartBody);
+            outerMultipart.addBodyPart(innerMultiPartBody);
 
             Theme theme = this.session.theme().getTheme(Theme.Type.EMAIL);
-            addAttachments(multipart, theme);
+            addAttachments(outerMultipart, theme);
 
             SMTPMessage msg = new SMTPMessage(session);
             msg.setFrom(toInternetAddress(from, fromDisplayName));
@@ -117,7 +117,7 @@ public class EmailWithAttachmentSenderProvider implements EmailSenderProvider {
 
             msg.setHeader("To", address);
             msg.setSubject(subject, "utf-8");
-            msg.setContent(multipart);
+            msg.setContent(outerMultipart);
             msg.saveChanges();
             msg.setSentDate(new Date());
 


### PR DESCRIPTION
# 1. Nested multiparts

If an email contains html, plain text and attachments, the html and plain text have to be in a nested multipart.

Example:

```
Content-Type: multipart/mixed; boundary="outerMultipart"
[Other headers]

--outerMultipart
Content-Type: multipart/alternative; boundary="innerMultipart"

--innerMultipart
Content-Type: text/plain; charset=us-ascii

This is the body in plain text for non-HTML mail clients

--innerMultipart
Content-Type: text/html; charset=us-ascii

This is the HTML message body <b>in bold!</b>


--innerMultipart--

--outerMultipart
Content-Type: application/octet-stream; name=attachment.pdf
Content-Transfer-Encoding: base64
Content-Disposition: attachment; filename=attachment.pdf

[Base-64 encoded file]

--outerMultipart--
```

# 2. Attachments

Using something like `<div src="cid:testfile"></div>` is only necessary if it's an attachment which should be included inside the HTML (like an inline image). If it's just an attachment (like a PDF file) it should be avoided to include the attachment inside the HTML.

Instead you can now provide a comma separated list of attachment in `theme.properties`.

This fixes the problem, that attachments were not shown in Outlook.